### PR TITLE
Pin path.py

### DIFF
--- a/hooks/requirements.txt
+++ b/hooks/requirements.txt
@@ -1,5 +1,5 @@
 -e git+https://github.com/whitmo/ansible-charm.git#egg=AnsibleCharm
 charmhelpers
 ansible>=1.9
-path.py
+path.py<=7.7.1
 docker-py


### PR DESCRIPTION
Due to bug 102 jaraco/path.py#102 path.py was
recently updated to remove an alias of "path" and this breaks thing in a
big way which warranted moving from inline dependency statements to
tracking deps.

This may not be an immediate issue anymore, but we're better off
tracking dependencies in a requirements.txt so we can mitigate design
changes like this moving forward
